### PR TITLE
Select audio track when exporting from ffmpeg

### DIFF
--- a/utils/ankiexport.py
+++ b/utils/ankiexport.py
@@ -106,7 +106,7 @@ class AnkiExporter():
                 '-ss', str(start),
                 '-to', str(end),
                 '-i', media_file,
-                '-map', '0:' + str(audio_track)
+                '-map', '0:' + str(audio_track),
                 '-acodec', 'mp3',
                 out_path
                 ]

--- a/utils/ankiexport.py
+++ b/utils/ankiexport.py
@@ -106,6 +106,7 @@ class AnkiExporter():
                 '-ss', str(start),
                 '-to', str(end),
                 '-i', media_file,
+                '-map', '0:' + str(audio_track)
                 '-acodec', 'mp3',
                 out_path
                 ]


### PR DESCRIPTION
This PR fixes #18 by selecting the audio track using [map](https://trac.ffmpeg.org/wiki/Map).