### PR TITLE
Fix an error created in previous PR

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,3 +1,4 @@
+mp.utils = require("mp.utils") -- Required for selene to work properly
 local utils = mp.utils
 local SelectionMenu = require('modules.selectionmenu')
 

--- a/mp.yml
+++ b/mp.yml
@@ -1,6 +1,6 @@
 # Taken from: https://github.com/mpv-player/mpv/blob/master/DOCS/man/lua.rst
 ---
-base: lua53
+base: lua51
 globals:
   mp.command:
     args:
@@ -111,6 +111,8 @@ globals:
   mp.msg.trace:
     args:
       - type: "..."
+  mp.utils:
+    property: full-write
   mp.utils.getcwd:
     args:
       - required: false


### PR DESCRIPTION
This was a pretty bad oversight on my part. Given how mp.msg is preloaded, I assumed the require was unnecessary, so I removed it without testing in #23, but for some reason you have to require mp.utils directly.

The issue (I'm assuming) is that they probably disappear or something as suggested in the mpv lua documentation ([link](https://github.com/mpv-player/mpv/blob/master/DOCS/man/lua.rst)):
> Be warned that any of these functions might disappear any time. They are not strictly part of the guaranteed API.

This fixes that regression that I created, apologies.