### PR TITLE
Change cchardet to faust-cchardet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 psutil
 requests
 pysubs2
-faust-cchardet
+cchardet; python_version < '3.10'
+faust-cchardet; python_version >= '3.10'
 ffsubsync
 rubysubs>=0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 psutil
 requests
 pysubs2
-cchardet
+faust-cchardet
 ffsubsync
 rubysubs>=0.1.4


### PR DESCRIPTION
The original package is no longer maintained- you may want to switch over to my fork when I finish adding wheels for ARM macOS and Windows.